### PR TITLE
Ignored Env param

### DIFF
--- a/src/kedro_error_emailer/error_handling.py
+++ b/src/kedro_error_emailer/error_handling.py
@@ -32,10 +32,16 @@ def error_handler(hook_func):
                 )
 
             params = get_mailer_param(args)
-            ignore_exceptions = params["ignored_exceptions"]
-            if e.__class__.__name__ in ignore_exceptions:
-                logger.warning(f"Ignoring mailing for {e.__class__.__name__} error.")
+            # Allow optional parameters, plus keeping it as None.
+            ignored_exceptions = params.get("ignored_exceptions", []) or []
+            if e.__class__.__name__ in ignored_exceptions:
+                logger.warning(
+                    f"Ignoring mailing for {e.__class__.__name__} error.")
                 raise e
+            
+            ignored_envs = params.get("ignored_envs", []) or []
+            if args[1].env in ignored_envs:
+                logger.warning(f"Ignoring mailing for {e.__class__.__name__} environment.")
 
             hook_module = hook_func.__module__
             tb = traceback.TracebackException.from_exception(e)


### PR DESCRIPTION
You can now ignore certain Kedro environment. 

⚠️ Warning: This is only applied to the error_handler decorator, like "ignore_exceptions". It should be applied to the other hooks when the issue will be fixed #1 

Furthermore, The parameters "ignore_exceptions" and "ignore_envs" can be optional (meaning they aren't necessary in the `parameters.yml`, + there is a guard if you were to keep the value empty, such as:
```yml
error_mailer:
  email:
    send_from: example@dodobird.ai
    send_to:
      - example@dodobird.ai
  ignored_exceptions: # Will still work
  ignored_envs:
    - base # Ignoring base env
    ```
